### PR TITLE
顧客一覧レビュー

### DIFF
--- a/src/components/Atoms/Button/CustomButton.vue
+++ b/src/components/Atoms/Button/CustomButton.vue
@@ -4,7 +4,7 @@
     :class="[
       buttonColor(buttonColorNumber),
     ]"
-    :disable="disableFlg"
+    :disabled="disableFlg"
   >
     {{ buttonName }}
   </button>

--- a/src/components/Atoms/Layout/Header.vue
+++ b/src/components/Atoms/Layout/Header.vue
@@ -1,13 +1,29 @@
 <template>
-  <div class="h-10 p-2 bg-white flex items-center">
-    <p class="test-center font-bold">{{ headerName }}</p>
+  <div class="h-10 p-2 bg-white flex items-center justify-between">
+    <div class="test-center flex font-bold">{{ headerName }}</div>
+    <CustomButton
+      v-if="createButtonTo"
+      button-name="新規作成"
+      @click="$router.push(createButtonTo)"
+      :disable-flg="true"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
-const props = defineProps<{
-  headerName: string
-}>();
+import CustomButton from '../../Atoms/Button/CustomButton.vue';
+
+interface Props {
+  /** ヘッダー名 */
+  headerName: string;
+  /** 新規作成ボタン遷移先 */
+  createButtonTo?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  createButtonTo: ''
+});
+
 </script>
 
 <style>

--- a/src/components/Atoms/Layout/Header.vue
+++ b/src/components/Atoms/Layout/Header.vue
@@ -5,7 +5,6 @@
       v-if="createButtonTo"
       button-name="新規作成"
       @click="$router.push(createButtonTo)"
-      :disable-flg="true"
     />
   </div>
 </template>

--- a/src/components/Atoms/Layout/SideBar.vue
+++ b/src/components/Atoms/Layout/SideBar.vue
@@ -10,7 +10,7 @@
       </div>
       <font-awesome-icon :icon="['fas', 'angle-right']" class="w-4 h-4 pr-2 font-black" />
     </router-link>
-    <router-link to="/customerCreate" class="flex justify-between items-center px-2 py-4 hover:bg-blue-500">
+    <router-link to="/customerList" class="flex justify-between items-center px-2 py-4 hover:bg-blue-500">
       <div class="flex items-center">
         <font-awesome-icon :icon="['fas', 'users']" class="w-4 h-4 pr-2 font-black" />
         <p>顧客管理</p>

--- a/src/components/Organisms/CustomerList/CustomerSearchDetail.vue
+++ b/src/components/Organisms/CustomerList/CustomerSearchDetail.vue
@@ -20,7 +20,7 @@
           <td class="border border-gray-300 p-2">{{ customer.lastName }}{{ customer.firstName }}</td>
           <td class="border border-gray-300 p-2">{{ customer.lastNameKana }}{{ customer.firstNameKana }}</td>
           <td class="border border-gray-300 p-2">{{ customer.age }}</td>
-          <td class="border border-gray-300 p-2">{{ customer.gender }}</td>
+          <td class="border border-gray-300 p-2">{{ Gender.getNameByCode(customer.gender) }}</td>
         </tr>
       </tbody>
     </table>
@@ -36,6 +36,7 @@
 import Modal from './Modal.vue';
 import { Customer } from '../../../models/Customer';
 import { ref } from 'vue';
+import { Gender } from '../../../constants/Gender';
 
 const props = defineProps<{
   customerList: Customer[]

--- a/src/components/Organisms/CustomerList/CustomerSearchHeader.vue
+++ b/src/components/Organisms/CustomerList/CustomerSearchHeader.vue
@@ -37,8 +37,9 @@
       />
     </div>
     <div>
-      <InputWithLabel
-        v-model:input-value='searchForm.gender'
+      <SelectBoxWithLabel
+        v-model:select-value="searchForm.gender"
+        :options="GenderList"
         label="性別"
       />
     </div>
@@ -50,6 +51,8 @@ import CustomButton from '../../Atoms/Button/CustomButton.vue';
 import { computed } from 'vue';
 import { useCustomerStore } from '../../../store/customer';
 import InputWithLabel from '../../Molecules/InputWithLabel.vue';
+import SelectBoxWithLabel from '../../Molecules/SelectBoxWithLabel.vue';
+import { GenderList } from '../../../constants/Gender';
 
 const customerStore = useCustomerStore();
 

--- a/src/components/Organisms/CustomerList/CustomerSearchHeader.vue
+++ b/src/components/Organisms/CustomerList/CustomerSearchHeader.vue
@@ -7,12 +7,12 @@
     <div class="flex">
       <CustomButton
         @click="search"
-        :button-name="'検索'"
+        button-name="検索"
         :button-color-number=1
       />
       <CustomButton
         @click="clearSearchCond"
-        :button-name="'クリア'"
+        button-name="クリア"
         class="ml-2"
       />
     </div>

--- a/src/constants/Gender.ts
+++ b/src/constants/Gender.ts
@@ -8,6 +8,9 @@ export const Gender = {
   FEMALE: new GenderConstant(2, "女性"),
   OTHERS: new GenderConstant(3, "その他"),
   NOANSWER: new GenderConstant(4, "回答しない"),
+  getNameByCode: (code: number | null): string => {
+    return <string>codeNameMap.get(code);
+  }
 };
 
 export const GenderList = [
@@ -17,13 +20,11 @@ export const GenderList = [
   new GenderConstant(4, "回答しない"),
 ];
 
-const getNameByCode = (code: number | null): string => {
-  return <string>codeNameMap.get(code);
-}
-
 const codeNameMap = new Map<number | null, string>();
 Object.values(Gender).forEach((elem) => {
-  codeNameMap.set(elem.code, elem.name);
+  if (elem instanceof GenderConstant) {
+    codeNameMap.set(elem.code, elem.name);
+  }
 });
 
 

--- a/src/constants/MessageStatus.ts
+++ b/src/constants/MessageStatus.ts
@@ -8,13 +8,14 @@ export const MessageStatus = {
   WARNING: new MessageStatusConstant(2, "warning"),
   DANGER: new MessageStatusConstant(3, "danger"),
   INFO: new MessageStatusConstant(4, "info"),
+  getNameByCode: (code: number | null): string => {
+    return <string>codeNameMap.get(code);
+  }
 };
-
-const getNameByCode = (code: number | null): string => {
-  return <string>codeNameMap.get(code);
-}
 
 const codeNameMap = new Map<number | null, string>();
 Object.values(MessageStatus).forEach((elem) => {
-  codeNameMap.set(elem.code, elem.name);
+  if (elem instanceof MessageStatusConstant) {
+    codeNameMap.set(elem.code, elem.name);
+  }
 });

--- a/src/constants/PrefectureId.ts
+++ b/src/constants/PrefectureId.ts
@@ -1,56 +1,58 @@
-import {ConstantBase} from './ConstantBase';
+import { ConstantBase } from "./ConstantBase";
 
-export class PrefectureIdConstant extends ConstantBase{
-}
+export class PrefectureIdConstant extends ConstantBase {}
 
 export const PrefectureId = {
-HOKKAIDO: new PrefectureIdConstant(1, "北海道"),
-AOMORI: new PrefectureIdConstant(2, "青森県"),
-IWATE: new PrefectureIdConstant(3, "岩手県"),
-MIYAGI: new PrefectureIdConstant(4, "宮城県"),
-AKITA: new PrefectureIdConstant(5, "秋田県"),
-YAMAGATA: new PrefectureIdConstant(6, "山形県"),
-FUKUSHIMA: new PrefectureIdConstant(7, "福島県"),
-IBARAKI: new PrefectureIdConstant(8, "茨城県"),
-TOCHIGI: new PrefectureIdConstant(9, "栃木県"),
-GUMMA: new PrefectureIdConstant(10, "群馬県"),
-SAITAMA: new PrefectureIdConstant(11, "埼玉県"),
-CHIBA: new PrefectureIdConstant(12, "千葉県"),
-TOKYO: new PrefectureIdConstant(13, "東京都"),
-KANAGAWA: new PrefectureIdConstant(14, "神奈川県"),
-NIIGATA: new PrefectureIdConstant(15, "新潟県"),
-TOYAMA: new PrefectureIdConstant(16, "富山県"),
-ISHIKAWA: new PrefectureIdConstant(17, "石川県"),
-FUKUI: new PrefectureIdConstant(18, "福井県"),
-YAMANASHI: new PrefectureIdConstant(19, "山梨県"),
-NAGANO: new PrefectureIdConstant(20, "長野県"),
-GIFU: new PrefectureIdConstant(21, "岐阜県"),
-SHIZUOKA: new PrefectureIdConstant(22, "静岡県"),
-AICHI: new PrefectureIdConstant(23, "愛知県"),
-MIE: new PrefectureIdConstant(24, "三重県"),
-SHIGA: new PrefectureIdConstant(25, "滋賀県"),
-KYOTO: new PrefectureIdConstant(26, "京都府"),
-OSAKA: new PrefectureIdConstant(27, "大阪府"),
-HYOGO: new PrefectureIdConstant(28, "兵庫県"),
-NARA: new PrefectureIdConstant(29, "奈良県"),
-WAKAYAMA: new PrefectureIdConstant(30, "和歌山県"),
-TOTTORI: new PrefectureIdConstant(31, "鳥取県"),
-SHIMANE: new PrefectureIdConstant(32, "島根県"),
-OKAYAMA: new PrefectureIdConstant(33, "岡山県"),
-HIROSHIMA: new PrefectureIdConstant(34, "広島県"),
-YAMAGUCHI: new PrefectureIdConstant(35, "山口県"),
-TOKUSHIMA: new PrefectureIdConstant(36, "徳島県"),
-KAGAWA: new PrefectureIdConstant(37, "香川県"),
-EHIME: new PrefectureIdConstant(38, "愛媛県"),
-KOCHI: new PrefectureIdConstant(39, "高知県"),
-FUKUOKA: new PrefectureIdConstant(40, "福岡県"),
-SAGA: new PrefectureIdConstant(41, "佐賀県"),
-NAGASAKI: new PrefectureIdConstant(42, "長崎県"),
-KUMAMOTO: new PrefectureIdConstant(43, "熊本県"),
-OITA: new PrefectureIdConstant(44, "大分県"),
-MIYAZAKI: new PrefectureIdConstant(45, "宮崎県"),
-KAGOSHIMA: new PrefectureIdConstant(46, "鹿児島県"),
-OKINAWA: new PrefectureIdConstant(47, "沖縄県"),
+  HOKKAIDO: new PrefectureIdConstant(1, "北海道"),
+  AOMORI: new PrefectureIdConstant(2, "青森県"),
+  IWATE: new PrefectureIdConstant(3, "岩手県"),
+  MIYAGI: new PrefectureIdConstant(4, "宮城県"),
+  AKITA: new PrefectureIdConstant(5, "秋田県"),
+  YAMAGATA: new PrefectureIdConstant(6, "山形県"),
+  FUKUSHIMA: new PrefectureIdConstant(7, "福島県"),
+  IBARAKI: new PrefectureIdConstant(8, "茨城県"),
+  TOCHIGI: new PrefectureIdConstant(9, "栃木県"),
+  GUMMA: new PrefectureIdConstant(10, "群馬県"),
+  SAITAMA: new PrefectureIdConstant(11, "埼玉県"),
+  CHIBA: new PrefectureIdConstant(12, "千葉県"),
+  TOKYO: new PrefectureIdConstant(13, "東京都"),
+  KANAGAWA: new PrefectureIdConstant(14, "神奈川県"),
+  NIIGATA: new PrefectureIdConstant(15, "新潟県"),
+  TOYAMA: new PrefectureIdConstant(16, "富山県"),
+  ISHIKAWA: new PrefectureIdConstant(17, "石川県"),
+  FUKUI: new PrefectureIdConstant(18, "福井県"),
+  YAMANASHI: new PrefectureIdConstant(19, "山梨県"),
+  NAGANO: new PrefectureIdConstant(20, "長野県"),
+  GIFU: new PrefectureIdConstant(21, "岐阜県"),
+  SHIZUOKA: new PrefectureIdConstant(22, "静岡県"),
+  AICHI: new PrefectureIdConstant(23, "愛知県"),
+  MIE: new PrefectureIdConstant(24, "三重県"),
+  SHIGA: new PrefectureIdConstant(25, "滋賀県"),
+  KYOTO: new PrefectureIdConstant(26, "京都府"),
+  OSAKA: new PrefectureIdConstant(27, "大阪府"),
+  HYOGO: new PrefectureIdConstant(28, "兵庫県"),
+  NARA: new PrefectureIdConstant(29, "奈良県"),
+  WAKAYAMA: new PrefectureIdConstant(30, "和歌山県"),
+  TOTTORI: new PrefectureIdConstant(31, "鳥取県"),
+  SHIMANE: new PrefectureIdConstant(32, "島根県"),
+  OKAYAMA: new PrefectureIdConstant(33, "岡山県"),
+  HIROSHIMA: new PrefectureIdConstant(34, "広島県"),
+  YAMAGUCHI: new PrefectureIdConstant(35, "山口県"),
+  TOKUSHIMA: new PrefectureIdConstant(36, "徳島県"),
+  KAGAWA: new PrefectureIdConstant(37, "香川県"),
+  EHIME: new PrefectureIdConstant(38, "愛媛県"),
+  KOCHI: new PrefectureIdConstant(39, "高知県"),
+  FUKUOKA: new PrefectureIdConstant(40, "福岡県"),
+  SAGA: new PrefectureIdConstant(41, "佐賀県"),
+  NAGASAKI: new PrefectureIdConstant(42, "長崎県"),
+  KUMAMOTO: new PrefectureIdConstant(43, "熊本県"),
+  OITA: new PrefectureIdConstant(44, "大分県"),
+  MIYAZAKI: new PrefectureIdConstant(45, "宮崎県"),
+  KAGOSHIMA: new PrefectureIdConstant(46, "鹿児島県"),
+  OKINAWA: new PrefectureIdConstant(47, "沖縄県"),
+  getNameByCode: (code: number | null): string => {
+    return <string>codeNameMap.get(code);
+  },
 };
 
 export const PrefectureIdList = [
@@ -103,13 +105,9 @@ export const PrefectureIdList = [
   new PrefectureIdConstant(47, "沖縄県"),
 ];
 
-const getNameByCode = (code: number | null): string => {
-  return <string>codeNameMap.get(code);
-}
-
 const codeNameMap = new Map<number | null, string>();
 Object.values(PrefectureId).forEach((elem) => {
-  codeNameMap.set(elem.code, elem.name);
+  if (elem instanceof PrefectureIdConstant) {
+    codeNameMap.set(elem.code, elem.name);
+  }
 });
-
-

--- a/src/constants/ReserveStates.ts
+++ b/src/constants/ReserveStates.ts
@@ -8,13 +8,14 @@ export const ReserveStates = {
   VISITED: new ReserveStatesConstant(2, "来店済"),
   CHANGE: new ReserveStatesConstant(3, "予約日時変更"),
   CANCEL: new ReserveStatesConstant(4, "キャンセル"),
+  getNameByCode: (code: number | null): string => {
+    return <string>codeNameMap.get(code);
+  }
 };
-
-const getNameByCode = (code: number | null): string => {
-  return <string>codeNameMap.get(code);
-}
 
 const codeNameMap = new Map<number | null, string>();
 Object.values(ReserveStates).forEach((elem) => {
-  codeNameMap.set(elem.code, elem.name);
+  if (elem instanceof ReserveStatesConstant) {
+    codeNameMap.set(elem.code, elem.name);
+  }
 });

--- a/src/views/CustomerList.vue
+++ b/src/views/CustomerList.vue
@@ -1,6 +1,9 @@
 <template>
   <div>
-    <Header :header-name="'顧客管理'" />
+    <Header
+      header-name="顧客管理"
+      createButtonTo="/customerCreate"
+    />
     <CustomerSearchHeader />
     <CustomerSearchDetail :customer-list="customerList" />
   </div>


### PR DESCRIPTION
### 主な修正内容

[サイドバー_顧客管理クリックで顧客一覧画面に遷移するよう修正](https://github.com/75ks/2022-front/commit/0c0a7845fb0b8601d8cf6c205ad3ba92f16cf6e6)
[Header部品に共通利用する新規作成ボタンを追加](https://github.com/75ks/2022-front/pull/34/commits/58063439928b479ea8c50a5308f726dd14e3e62a)
⇛顧客一覧画面から新規作成ボタン押下で顧客作成画面に遷移するよう修正した。

[定数から名称を取得する処理がうまく行ってなかったので修正](https://github.com/75ks/2022-front/pull/34/commits/aabbfa87404600ed0282414f05bbf05b194fa68b)
[性別をコード値から名称を取得するよう修正](https://github.com/75ks/2022-front/pull/34/commits/2734eef4388589ff8e84908fe6713428d4e42b1d)
⇛一覧で性別が数字で表示されていたので、名称で表示されるよう修正した。

[性別の検索条件の欄を選択肢から選択するよう修正](https://github.com/75ks/2022-front/pull/34/commits/fd36ae1be3eab3b75546a443c6e2bf37fd7bfba9)
⇛性別を選択肢から選択するよう修正した。

